### PR TITLE
tagFile with ccsid=0 removes the tag

### DIFF
--- a/porting/polyfill.c
+++ b/porting/polyfill.c
@@ -122,6 +122,7 @@ int convertOpenStream(int fd, unsigned short fileCCSID){
 }
 
 #define CCSID_BINARY 65535
+#define CCSID_NONE 0
 
 int tagFile(const char *pathname, unsigned short ccsid){
 #if defined(_LP64) && defined(ZCOMPILE_CLANG)
@@ -130,7 +131,11 @@ int tagFile(const char *pathname, unsigned short ccsid){
 
   attr.att_filetagchg = 1;
   attr.att_filetag.ft_ccsid = ccsid;
-  attr.att_filetag.ft_txtflag = (ccsid == CCSID_BINARY ? 0 : 1);
+  if (ccsid == CCSID_NONE || ccsid == CCSID_BINARY ) {
+    attr.att_filetag.ft_txtflag = 0;
+  } else {
+    attr.att_filetag.ft_txtflag = 1;
+  }
 
   int res = __chattr64((char*)pathname, &attr, sizeof(attr));
 #else
@@ -139,7 +144,11 @@ int tagFile(const char *pathname, unsigned short ccsid){
 
   attr.att_filetagchg = 1;
   attr.att_filetag.ft_ccsid = ccsid;
-  attr.att_filetag.ft_txtflag = (ccsid == CCSID_BINARY ? 0 : 1);
+  if (ccsid == CCSID_NONE || ccsid == CCSID_BINARY ) {
+    attr.att_filetag.ft_txtflag = 0;
+  } else {
+    attr.att_filetag.ft_txtflag = 1;
+  }
 
   int res = __chattr((char*)pathname, &attr, sizeof(attr));
 #endif


### PR DESCRIPTION
# Bug

`tagFile` works for any CCSID except 0, which should remove the tag. This PR fixes that.

# Tests

## Java Script

```
import * as zos from 'zos'
const FILE = './a.txt';

let result = zos.zstat(FILE);
console.log(`File ${FILE } before: isText: ${result[0].isText}, ccsid: ${result[0].ccsid}`);

const rc = zos.changeTag(FILE, 0);
console.log(`"zos.changeTag" return code: ${rc}`);

result = zos.zstat(FILE);
console.log(`File ${FILE } after: isText: ${result[0].isText}, ccsid: ${result[0].ccsid}`);

```

## Shell
```
#!/bin/sh
/pathToBroken/configmgr -script testch.js
echo " ---- "
/pathToFixed/configmgr -script testch.js
```

## Result
```
File ./a.txt before: isText: true, ccsid: 819
��/��ʀ�/�%������ǀ���>?���"zos.changeTag" return code: -1
File ./a.txt after: isText: true, ccsid: 819
 ----
File ./a.txt before: isText: true, ccsid: 819
"zos.changeTag" return code: 0
File ./a.txt after: isText: false, ccsid: 0
```

## Note
This PR does not solve the garbage on the screen.