### PR TITLE
printf2 without extra char

### DIFF
--- a/porting/debugutil.c
+++ b/porting/debugutil.c
@@ -47,7 +47,7 @@ void printf2(char *formatString, ...){
   cnt = vsnprintf(text,sizeof(text),formatString,argPointer);
   va_end(argPointer);
   toEBCDIC(text,cnt);
-  printf("%s\n",text);
+  printf("%s",text);
 }
 
 int putchar2(int c){


### PR DESCRIPTION
Changed line in `printf2` function combines `\n` and `text`, but only `text` was converted to EBCDIC.

Before the change:
`printf2("A\n") -> 0x 41 0A 8E`
```
A
�
```

After the change
`printf2("A\n") -> 0x 41 0A`