### PR TITLE
Remove debug msgs

### DIFF
--- a/porting/polyfill.c
+++ b/porting/polyfill.c
@@ -152,9 +152,7 @@ int tagFile(const char *pathname, unsigned short ccsid){
 
   int res = __chattr((char*)pathname, &attr, sizeof(attr));
 #endif
-  if (res){
-    printf("chattr failed with errno=%d\n",errno);
-  }
+
   return res;
 }
 

--- a/porting/polyfill.c
+++ b/porting/polyfill.c
@@ -115,9 +115,6 @@ int convertOpenStream(int fd, unsigned short fileCCSID){
   conversionArg.pccsid = 0;
   conversionArg.fccsid = fileCCSID; /* 1047; */
   int res = fcntl(fd, F_CONTROL_CVT, &conversionArg);
-  if (res != 0){
-    printf("* internal error* convertOpenStream(), and ascii/ebcdic function, called fcntl failed errno=%d\n",errno);
-  }
   return res;
 }
 


### PR DESCRIPTION
# Problem

Some C functions has debug messages, which is fine. But:
* Incorrect encoding makes it difficult to read
* When fails as javascript call, it should respect `configmgr` trace level and some message format
* Deleting these messages is the most simple solution

## ChangeTag
[`zos.changeTag`](https://github.com/zowe/zowe-common-c/issues/426) prints garbage when fails.

### Without fix
```
��/��ʀ�/�%������ǀ���>?���zos.changeTag()=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(null)=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(undefined)=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(-12)=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(0)=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(28)=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(./file, which does not exit)=-1
��/��ʀ�/�%������ǀ���>?���zos.changeTag(./file, which does not exit,250000)=-1
```

### With fix
```
zos.changeTag()=-1
zos.changeTag(null)=-1
zos.changeTag(undefined)=-1
zos.changeTag(-12)=-1
zos.changeTag(0)=-1
zos.changeTag(28)=-1
zos.changeTag(./file, which does not exit)=-1
zos.changeTag(./file, which does not exit,250000)=-1
```
## ChangeStreamCCSID

`zos.changeStreamCCSID` prints garbage when fails.

### Without fix
```
zos.changeStreamCCSID("")=0
zos.changeStreamCCSID("null")=0
zos.changeStreamCCSID("undefined")=0
zos.changeStreamCCSID("true")=0
zos.changeStreamCCSID("false")=0
���>���>/%����?ʊ��?>����|��>����/_����/>��/���������Ā��>���?>���/%%�����>�%��/�%������>?����zos.changeStreamCCSID("-16")=-1
zos.changeStreamCCSID("0")=0
���>���>/%����?ʊ��?>����|��>����/_����/>��/���������Ā��>���?>���/%%�����>�%��/�%������>?����zos.changeStreamCCSID("256")=-1
���>���>/%����?ʊ��?>����|��>����/_����/>��/���������Ā��>���?>���/%%�����>�%��/�%������>?����zos.changeStreamCCSID("3.141592")=-1
���>���>/%����?ʊ��?>����|��>����/_����/>��/���������Ā��>���?>���/%%�����>�%��/�%������>?����zos.changeStreamCCSID("999999999")=-1
zos.changeStreamCCSID("["banana","apple","kiwi"]")=0
zos.changeStreamCCSID("{"success":"guaranteed"}")=0
```

### With fix
```
zos.changeStreamCCSID("")=0
zos.changeStreamCCSID("null")=0
zos.changeStreamCCSID("undefined")=0
zos.changeStreamCCSID("true")=0
zos.changeStreamCCSID("false")=0
zos.changeStreamCCSID("-16")=-1
zos.changeStreamCCSID("0")=0
zos.changeStreamCCSID("256")=-1
zos.changeStreamCCSID("3.141592")=-1
zos.changeStreamCCSID("999999999")=-1
zos.changeStreamCCSID("["banana","apple","kiwi"]")=0
zos.changeStreamCCSID("{"success":"guaranteed"}")=0
```